### PR TITLE
Move package.json main into description.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,7 @@
 {
 	"name": "boilerplate-project-stockchecker",
 	"version": "0.0.1",
-	"description": "",
-	"main": "InfoSec project for freeCodeCamp",
+	"description": "InfoSec project for freeCodeCamp",
 	"scripts": {
 		"start": "node server.js"
 	},


### PR DESCRIPTION
Minor edit, it looks like when this `package.json` was made, what should've been put in the `description` field was put in `main` instead.

Has no impact on functionality whatsoever.